### PR TITLE
Dragndrop sortable containers attempt2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.15.0",
@@ -209,6 +210,19 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "next": "^15.1.3",
         "react": "^18",
         "react-dom": "^18",
-        "styled-components": "^6.1.13"
+        "styled-components": "^6.1.13",
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -6006,6 +6007,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "next": "^15.1.3",
     "react": "^18",
     "react-dom": "^18",
-    "styled-components": "^6.1.13"
+    "styled-components": "^6.1.13",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/inventory/inventoryReducer.tsx
+++ b/src/app/inventory/inventoryReducer.tsx
@@ -1,0 +1,166 @@
+import { Data } from "@/components/tool/toolWindow"
+import { createData } from "./page";
+import { arrayMove } from "@dnd-kit/sortable";
+import { TOOL_WINDOW_ID } from "@/data/constants";
+
+export enum InventoryActions {
+    REPLACE_TOOL,
+    ADD_TOOL,
+    ADD_TOOLS,
+    ADD_CONTAINER,
+    REMOVE,
+    REMOVE_CONTAINER,
+    SPLICE
+}
+
+export interface CurrentInventoryAction {
+    type: InventoryActions,
+    payload: {
+        containerId: string,
+        newTool?: Data,
+        newTools?: Data[],
+        toolId?: string,
+        overToolId?: string,
+        overContainerId?: string,
+        uniqueId?: number,
+    }
+}
+
+export type CurrentInventory = { [key: string]: Data[] }
+
+export function currentInventoryReducer(state: CurrentInventory, action: CurrentInventoryAction): CurrentInventory {
+    switch (action.type) {
+        case InventoryActions.REPLACE_TOOL:
+            if (action.payload.toolId === undefined || action.payload.newTool === undefined) {
+                console.log("Cannot replace tool as no toolId or newTool exists");
+                return state;
+            }
+            
+            const newItems = state[action.payload.containerId].map(item => 
+                item.id === action.payload.toolId ? action.payload.newTool : item
+            );
+            
+            return {
+                ...state,
+                [action.payload.containerId]: newItems
+            };
+        case InventoryActions.ADD_CONTAINER:
+            
+            return {
+                ...state,
+                [action.payload.containerId]: []
+            };
+        case InventoryActions.ADD_TOOLS:
+            if (action.payload.newTools === undefined) {
+                console.log("Cannot add new tool as no new tool exists");
+                return state;
+            }
+            return {
+                ...state,
+                [action.payload.containerId]: [...action.payload.newTools]
+            };
+        case InventoryActions.ADD_TOOL:
+            if (action.payload.newTool === undefined) {
+                console.log("Cannot add new tool as no new tool exists");
+                return state;
+            }
+            return {
+                ...state,
+                [action.payload.containerId]: [
+                    ...state[action.payload.containerId],
+                    action.payload.newTool
+                ]
+            };
+        case InventoryActions.REMOVE:
+            if (action.payload.toolId === undefined) {
+                console.log("Cannot remove tool as toolid exists");
+                return state;
+            }
+            return {
+                ...state,
+                [action.payload.containerId]: state[action.payload.containerId].filter(row => row.id !== action.payload.toolId)
+            };
+        case InventoryActions.REMOVE_CONTAINER:
+            delete state[action.payload.containerId];
+            return {
+                ...state
+            };
+        case InventoryActions.SPLICE:
+            if (action.payload.overContainerId === undefined ||
+                action.payload.toolId === undefined ||
+                action.payload.overToolId === undefined ||
+                action.payload.uniqueId === undefined
+            ) {
+                console.log("Cannot remove tool as overContainerId exists");
+                return state;
+            }
+            const activeItems = state[action.payload.containerId];
+            const overItems = state[action.payload.overContainerId];
+
+            const activeIndex = activeItems.findIndex(
+                (item) => item.id === action.payload.toolId
+            );
+            let overIndex = activeItems.findIndex(
+                (item) => item.id === action.payload.overToolId
+            );
+
+            if (activeIndex === -1) {
+                // really not sure how we get to this state where we don't know where the original
+                return state
+            }
+
+            let data = state[action.payload.containerId][activeIndex]
+
+            // dragging over the same container
+            if (activeItems === overItems) {
+                return {
+                    ...state,
+                    [action.payload.overContainerId]: arrayMove(overItems, activeIndex, overIndex)
+                }
+            }
+
+            // return {
+            //     ...state
+            // }
+
+            // // WE ARE MOVING TOOL FROM TOOL WINDOW
+            if (action.payload.containerId === TOOL_WINDOW_ID) {
+                // newData = {
+                //     ...newData,
+                //     id: `${newData.name}-${String(action.payload.uniqueId)}`
+                // }
+
+                return {
+                    ...state,
+                    [action.payload.overContainerId]: [
+                        ...state[action.payload.overContainerId].slice(0, overIndex),
+                        data,
+                        ...state[action.payload.overContainerId].slice(
+                            overIndex,
+                            state[action.payload.overContainerId].length
+                        ),
+                    ],
+                };
+            } else {
+                return {
+                    ...state,
+                    [action.payload.containerId]: [
+                        ...state[action.payload.containerId].filter(
+                            (item) => item.id !== action.payload.toolId
+                        ),
+                    ],
+                    [action.payload.overContainerId]: [
+                        ...state[action.payload.overContainerId].slice(0, overIndex),
+                        data,
+                        ...state[action.payload.overContainerId].slice(
+                            overIndex,
+                            state[action.payload.overContainerId].length
+                        ),
+                    ],
+                };
+            }
+
+        default:
+            throw new Error('Current Inventory Unhandled action type');
+    }
+}

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import ContainerWindow from '@/components/container/containerWindow';
-import ToolWindow from '@/components/tool/toolWindow';
+import DraggableTool from '@/components/tool/draggableTool';
+import ToolWindow, { Data } from '@/components/tool/toolWindow';
+import { DndContext, DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent } from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+import { createContext, useState } from 'react';
 import styled from 'styled-components';
 
 const ToolContainer = styled.div`
@@ -20,17 +24,105 @@ const Page = styled.div`
     height: calc(100vh - 40px);
 `
 
+
+interface DroppedDataContextType {
+    data: Data | undefined;
+    droppableId: string;
+    droppedCount: number; // this can't be the right way to track when something is dropped
+}
+
+export const DroppedDataContext = createContext<DroppedDataContextType | undefined>(undefined);
+
 function Inventory() {
+
+    const [activeId, setActiveId] = useState<string>('')
+    const [droppableId, setDroppableId] = useState<string>('')
+    const [droppedCount, setDroppedCount] = useState<number>(0)
+    const [data, setData] = useState<Data | undefined>(undefined)
+
+    function createData(eventData: any) {
+        const data: Data = {
+            name: eventData.name,
+            weight: eventData.weight,
+            category: eventData.category,
+            id: eventData.id,
+        };
+        return data;
+    }
+
+    function handleDragStart(event: DragStartEvent) {
+        // TODO: This should be a constructor, and data should at this point be a class of its own
+        const data: Data | undefined = createData(event.active.data.current);
+        if (data === undefined) return
+        setData(data);
+        setActiveId(String(event.active.id))
+    }
+
+    function handleDragEnd(event: DragEndEvent) {
+        setActiveId('')
+        setDroppableId(String(event.over?.id))
+        setDroppedCount(droppedCount + 1)
+
+        swapActiveToOver(event)
+    }
+
+    function handleDragOver(event: DragOverEvent) {
+        console.log(event)
+        swapActiveToOver(event)
+    }
+
+    function swapActiveToOver(event: { active: any; over: any; }) {
+        // CAVEAT you only get the id's in sortable.items, NOT the element itself
+
+
+        // TODO: I have to have a data object in context that is always up to date with the most recent state of all data objects
+        // Then I can simply slice the active element inside the over container
+
+
+        const { active, over } = event;
+        if (active && over && active.data.current && active.id !== over.id) {
+            const setItems: React.Dispatch<React.SetStateAction<Data[]>> = active.data.current.setTools
+            setItems((items) => {
+                const oldIndex = items.findIndex((item) => item.id === active.id);
+                const newIndex = items.findIndex((item) => item.id === over.id);
+                if (oldIndex === -1 || newIndex == -1) {
+                    // different containers
+                    const data = createData(event.active.data.current)
+                    const newArr = [
+                        ...items.slice(0, oldIndex),
+                        createData(active),
+                        ...items.slice(0, oldIndex),
+                    ]
+                    return items
+                }
+                return arrayMove(items, oldIndex, newIndex);
+            });
+        }
+    }
+
     return (
         <Page>
-            <ToolContainer>
-                <ToolWindow />
-            </ToolContainer>
-            <PackContainer>
-                <ContainerWindow />
-            </PackContainer>
+            <DroppedDataContext.Provider value={{ data, droppableId, droppedCount }}>
+                <DndContext
+                    onDragStart={handleDragStart}
+                    onDragEnd={handleDragEnd}
+                    onDragOver={handleDragOver}
+                >
+                    <ToolContainer>
+                        <ToolWindow />
+                    </ToolContainer>
+                    <PackContainer>
+                        <ContainerWindow />
+                    </PackContainer>
+
+                    <DragOverlay>
+                        {activeId !== '' && data && <DraggableTool _data={data} hoveredRow={''} setHoveredRow={(id: string) => { }} deleteClick={(id: string) => { }} />}
+                    </DragOverlay>
+                </DndContext>
+            </DroppedDataContext.Provider>
         </Page>
     )
 }
 
-export default Inventory
+
+export default Inventory;

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -67,6 +67,7 @@ export function createData(eventData: any) {
 function Inventory() {
     const [activeId, setActiveId] = useState<string>('')
     const [uniqueId, setUniqueId] = useState<number>(1000000); // definitely not bulletproof
+    const [hoverContainerId, setHoverContainerId] = useState<string>('')
     const [droppableId, setDroppableId] = useState<string>('')
     const [droppedCount, setDroppedCount] = useState<number>(0)
     const [data, setData] = useState<Data>({id: "none", category: Category.ACCESSORIES, weight: 0, name: ''})
@@ -82,11 +83,11 @@ function Inventory() {
         }
         if (data === undefined) return
         setData(data);
+        setHoverContainerId(containerId)
         setActiveId(String(event.active.id))
     }
 
     function handleDragEnd(event: DragEndEvent) {
-        console.log('HUHHHHHHH ENDDINGGG')
         const data: Data | undefined = createData(event.active.data.current);
         if (!data || event.over === undefined || event.over === null) return
         if (event.over.data.current?.containerId === TOOL_WINDOW_ID) {
@@ -107,6 +108,7 @@ function Inventory() {
         })
         setActiveId('')
         setUniqueId(uniqueId + 1)
+        setHoverContainerId('')
     }
 
     function handleDragOver(event: DragOverEvent) {
@@ -162,7 +164,7 @@ function Inventory() {
                         </PackContainer>
 
                         <DragOverlay>
-                            {activeId !== '' && data && <DraggableTool _data={data} hoveredRow={''} setHoveredRow={(id: string) => { }} deleteClick={(id: string) => { }} containerId={'current_hover'} />}
+                            {activeId !== '' && data && <DraggableTool _data={data} hoveredRow={''} setHoveredRow={(id: string) => { }} deleteClick={(id: string) => { }} containerId={hoverContainerId} />}
                         </DragOverlay>
                     </DndContext>
                 </DroppedDataContext.Provider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import { useState, createContext } from 'react';
 import { Inter } from 'next/font/google'
 import './globals.css'
 import styled from 'styled-components';
-import { DndContext, DragEndEvent, DragOverlay, DragStartEvent } from '@dnd-kit/core';
-import { Data } from '@/components/tool/toolWindow';
 import Header from '@/components/header/header';
-import DraggableTool from '@/components/tool/draggableTool';
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -33,34 +29,11 @@ const Item = styled.div`
   background-color: #ffffff;
 `
 
-interface DroppedDataContextType {
-  data: Data | undefined;
-  droppableId: string;
-  droppedCount: number; // this can't be the right way to track when something is dropped
-}
-
-export const DroppedDataContext = createContext<DroppedDataContextType | undefined>(undefined);
-
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const [activeId, setActiveId] = useState<string>('')
-  const [droppableId, setDroppableId] = useState<string>('')
-  const [droppedCount, setDroppedCount] = useState<number>(0)
-  const [data, setData] = useState<Data | undefined>(undefined)
-
-  function handleDragStart(event: DragStartEvent) {
-    setData(event.active.data.current as Data);
-    setActiveId(String(event.active.id))
-  }
-
-  function handleDragEnd(event: DragEndEvent) {
-    setActiveId('')
-    setDroppableId(String(event.over?.id))
-    setDroppedCount(droppedCount + 1)
-  }
 
   return (
     <html lang="en" style={{ height: '100%' }} suppressHydrationWarning>
@@ -68,20 +41,11 @@ export default function RootLayout({
         <PageWithHeader>
           <Header />
           <Page>
-            <DroppedDataContext.Provider value={{ data, droppableId, droppedCount }}>
-              <DndContext
-                onDragStart={handleDragStart}
-                onDragEnd={handleDragEnd}
-              >
-                <Content>{children}</Content>
-                <DragOverlay>
-                  {activeId !== '' && data && <DraggableTool _data={data} hoveredRow={''} setHoveredRow={(id: string) => {}} deleteClick={(id: string) => {}}/>}
-                </DragOverlay>
-              </DndContext>
-            </DroppedDataContext.Provider>
+            <Content>{children}</Content>
           </Page>
         </PageWithHeader>
       </body>
     </html>
   )
 }
+

--- a/src/components/container/containerWindow.tsx
+++ b/src/components/container/containerWindow.tsx
@@ -18,16 +18,13 @@ const ContainerDiv = styled.div`
 `
 
 const ContainerWindow = ({ }: CardProps) => {
-    const [containers, setContainers] = useState<string[]>([]);
     const [hoveredContainer, setHoveredContainer] = useState<string>('');
     const [uniqueId, setUniqueId] = useState<number>(0);
 
     const currentInventoryContext = useCurrentInventoryState();
 
     const addBackpack = () => {
-        // let newContainers = [...containers, `backpack ${uniqueId}`]
         setUniqueId(uniqueId + 1)
-        // setContainers(newContainers)
         currentInventoryContext.currentInventoryDispatcher({
             type: InventoryActions.ADD_CONTAINER,
             payload: {

--- a/src/components/container/containerWindow.tsx
+++ b/src/components/container/containerWindow.tsx
@@ -3,6 +3,9 @@ import styled from 'styled-components';
 import BackpackTwoToneIcon from '@mui/icons-material/BackpackTwoTone';
 import IconButton from '@mui/material/IconButton';
 import DroppableContainer from './droppableContainer';
+import { useCurrentInventoryState } from '@/app/inventory/page';
+import { TOOL_WINDOW_ID } from '@/data/constants';
+import { InventoryActions } from '@/app/inventory/inventoryReducer';
 
 interface CardProps {
 }
@@ -19,20 +22,27 @@ const ContainerWindow = ({ }: CardProps) => {
     const [hoveredContainer, setHoveredContainer] = useState<string>('');
     const [uniqueId, setUniqueId] = useState<number>(0);
 
+    const currentInventoryContext = useCurrentInventoryState();
+
     const addBackpack = () => {
-        let newContainers = [...containers, `backpack ${uniqueId}`]
+        // let newContainers = [...containers, `backpack ${uniqueId}`]
         setUniqueId(uniqueId + 1)
-        setContainers(newContainers)
+        // setContainers(newContainers)
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.ADD_CONTAINER,
+            payload: {
+                containerId: `backpack ${uniqueId}`
+            }
+        })
     }
 
     const deleteClick = (id: string) => {
-        const newContainers: string[] = [];
-        containers.forEach((container) => {
-            if (container !== id) {
-                newContainers.push(container)
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REMOVE_CONTAINER,
+            payload: {
+                containerId: id
             }
         })
-        setContainers(newContainers);
     }
 
     return (
@@ -40,10 +50,13 @@ const ContainerWindow = ({ }: CardProps) => {
             <IconButton onClick={addBackpack} color="primary">
                 <BackpackTwoToneIcon />
             </IconButton>
-            {containers.map((value) => {
-                const id = `${value}`
-                return <DroppableContainer key={id} id={id} title={value} hoveredContainer={hoveredContainer} setHoveredContainer={setHoveredContainer} deleteClickContainer={deleteClick} />
-            })}
+            {
+                Object.keys(currentInventoryContext.currentInventory).map((value) => {
+                    if (value === TOOL_WINDOW_ID) return
+                    const id = `${value}`
+                    return <DroppableContainer key={id} id={id} title={value} hoveredContainer={hoveredContainer} setHoveredContainer={setHoveredContainer} deleteClickContainer={deleteClick} />
+                })
+            }
         </ContainerDiv>
     );
 };

--- a/src/components/container/droppableContainer.tsx
+++ b/src/components/container/droppableContainer.tsx
@@ -6,6 +6,7 @@ import { Data } from '../tool/toolWindow';
 import { DroppedDataContext } from '@/app/inventory/page';
 import IconButton from '@mui/material/IconButton';
 import ClearIcon from '@mui/icons-material/Clear';
+import { SortableContext } from '@dnd-kit/sortable';
 
 
 const ContainerCardContainer = styled.div`
@@ -120,11 +121,13 @@ const DroppableContainer = ({ id, title, hoveredContainer, deleteClickContainer,
                     </IconButton>
                 </ContainerTitleContainer>
                 <ContainerTools>
-                    {tools.map((tool) => {
-                        return (
-                            <DraggableTool key={tool.id} _data={tool} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClickTools} setTools={setTools} />
-                        )
-                    })}
+                    <SortableContext items={tools}>
+                        {tools.map((tool) => {
+                            return (
+                                <DraggableTool key={tool.id} _data={tool} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClickTools} setTools={setTools} />
+                            )
+                        })}
+                    </SortableContext>
                 </ContainerTools>
             </ContainerCardContent>
         </ContainerCardContainer>

--- a/src/components/container/droppableContainer.tsx
+++ b/src/components/container/droppableContainer.tsx
@@ -3,7 +3,7 @@ import { useDroppable } from '@dnd-kit/core';
 import styled from 'styled-components';
 import DraggableTool from '../tool/draggableTool';
 import { Data } from '../tool/toolWindow';
-import { DroppedDataContext } from '@/app/layout';
+import { DroppedDataContext } from '@/app/inventory/page';
 import IconButton from '@mui/material/IconButton';
 import ClearIcon from '@mui/icons-material/Clear';
 

--- a/src/components/container/droppableContainer.tsx
+++ b/src/components/container/droppableContainer.tsx
@@ -2,11 +2,11 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import styled from 'styled-components';
 import DraggableTool from '../tool/draggableTool';
-import { Data } from '../tool/toolWindow';
-import { DroppedDataContext } from '@/app/inventory/page';
+import { DroppedDataContext, useCurrentInventoryState } from '@/app/inventory/page';
 import IconButton from '@mui/material/IconButton';
 import ClearIcon from '@mui/icons-material/Clear';
 import { SortableContext } from '@dnd-kit/sortable';
+import { InventoryActions } from '@/app/inventory/inventoryReducer';
 
 
 const ContainerCardContainer = styled.div`
@@ -51,43 +51,39 @@ const DroppableContainer = ({ id, title, hoveredContainer, deleteClickContainer,
     const { isOver, setNodeRef } = useDroppable({
         id: id,
     });
-    const [tools, setTools] = useState<Data[]>([]);
     const [hoveredRow, setHoveredRow] = useState<string>('');
-    const [uniqueId, setUniqueId] = useState<number>(1000000); // definitely not bulletproof
     const [weight, setWeight] = useState<number>(0);
-
-    const droppedData = useContext(DroppedDataContext)
+    const currentInventoryContext = useCurrentInventoryState();
 
     useEffect(() => {
-        if (droppedData?.data && droppedData.droppableId === id) { // is this still going to register as true when the context changes?
-            let droppedDataCopy = { ...droppedData.data }
-            droppedDataCopy.id = `${id}-${String(uniqueId)}`
-            let newTools = [...tools, droppedDataCopy]
-            setTools(newTools)
-            setUniqueId(uniqueId + 1)
-        }
-    }, [droppedData?.droppedCount])
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.ADD_CONTAINER,
+            payload: {
+                containerId: id
+            }
+        })
+    }, [])
 
     useEffect(() => {
         let newWeight = 0
-        tools.forEach((tool) => {
+        currentInventoryContext.currentInventory[id].forEach((tool) => {
             newWeight += tool.weight
         })
         setWeight(newWeight)
-    }, [tools])
+    }, [currentInventoryContext.currentInventory]) // this is very important to render when it changes
 
     const hoverOverStyle: React.CSSProperties = {
         backgroundColor: isOver ? '#e1ffca' : '#fff',
     }
 
-    const deleteClickTools = (id: string) => {
-        const newTools: Data[] = [];
-        tools.forEach((row) => {
-            if (row.id !== id) {
-                newTools.push(row)
+    const deleteClickTools = (toolId: string) => {
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REMOVE,
+            payload: {
+                containerId: id,
+                toolId: toolId
             }
         })
-        setTools(newTools);
     }
 
     const handleMouseEnter = (id: string) => {
@@ -121,13 +117,13 @@ const DroppableContainer = ({ id, title, hoveredContainer, deleteClickContainer,
                     </IconButton>
                 </ContainerTitleContainer>
                 <ContainerTools>
-                    <SortableContext items={tools}>
-                        {tools.map((tool) => {
-                            return (
-                                <DraggableTool key={tool.id} _data={tool} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClickTools} setTools={setTools} />
-                            )
-                        })}
-                    </SortableContext>
+                        <SortableContext items={id in currentInventoryContext.currentInventory ? currentInventoryContext.currentInventory[id] : []}>
+                            {id in currentInventoryContext.currentInventory && currentInventoryContext.currentInventory[id].map((tool) => {
+                                return (
+                                    <DraggableTool key={tool.id} _data={tool} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClickTools} containerId={id} />
+                                )
+                            })}
+                        </SortableContext>
                 </ContainerTools>
             </ContainerCardContent>
         </ContainerCardContainer>

--- a/src/components/tool/draggableTool.tsx
+++ b/src/components/tool/draggableTool.tsx
@@ -7,23 +7,9 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { useDraggable } from '@dnd-kit/core';
 import { Menu, MenuItem } from '@mui/material';
 
-import FlatwareIcon from '@mui/icons-material/Flatware';
-import CheckroomIcon from '@mui/icons-material/Checkroom';
-import SoapIcon from '@mui/icons-material/Soap';
-import HandymanIcon from '@mui/icons-material/Handyman';
-import {
-    IconShirt,
-    IconBaguette,
-    IconMeat,
-    IconSock,
-    IconTent,
-} from '@tabler/icons-react';
-import {
-    Boot,
-    Pants,
-    Sock,
-} from '@phosphor-icons/react';
 import { Category, categoryToIconMappings } from '@/data/constants';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 
 const ToolName = styled.div`
@@ -159,7 +145,8 @@ const DraggableTool = ({ _data, hoveredRow, setHoveredRow, deleteClick, setTools
             key={data.id}
             onMouseEnter={() => handleMouseEnter(data.id)}
             onMouseLeave={handleMouseLeave}
-            id={`${data.name} ${data.id}`}
+            id={data.id}
+            setTools={setTools}
         >
             <IconButton
                 sx={{ visibility: hoveredRow === data.id ? '' : 'hidden' }}
@@ -229,12 +216,18 @@ interface DraggableItemProps {
     id: string;
     onMouseEnter?: React.MouseEventHandler<HTMLTableRowElement>;
     onMouseLeave?: React.MouseEventHandler<HTMLTableRowElement>;
+    setTools?: React.Dispatch<React.SetStateAction<Data[]>>;
 }
 
-const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMouseEnter, onMouseLeave }) => {
-    const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMouseEnter, onMouseLeave, setTools }) => {
+    const dataFordndContext = { 
+        ...data,
+        setTools: setTools,
+    }
+
+    const { attributes, listeners, setNodeRef, transform, isDragging, setActivatorNodeRef } = useSortable({
         id,
-        data: data
+        data: dataFordndContext,
     });
 
     const style: React.CSSProperties = {
@@ -246,6 +239,8 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMou
         width: '100%',
         // maxWidth: '100%',
         backgroundColor: '#fff',
+        border: '0.5px solid #6f6f6f',
+        borderRadius: '10px',
     };
 
     return (
@@ -254,10 +249,10 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMou
             ref={setNodeRef}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            >
+        >
             {children}
             <IconButton
-                // ref={setNodeRef}
+                ref={setActivatorNodeRef}
                 {...attributes}
                 {...listeners}
                 onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#f2f2f2'}

--- a/src/components/tool/draggableTool.tsx
+++ b/src/components/tool/draggableTool.tsx
@@ -225,7 +225,7 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMou
         setTools: setTools,
     }
 
-    const { attributes, listeners, setNodeRef, transform, isDragging, setActivatorNodeRef } = useSortable({
+    const { attributes, listeners, setNodeRef, transform, isDragging, setActivatorNodeRef, transition } = useSortable({
         id,
         data: dataFordndContext,
     });
@@ -241,6 +241,8 @@ const DraggableItem: React.FC<DraggableItemProps> = ({ data, children, id, onMou
         backgroundColor: '#fff',
         border: '0.5px solid #6f6f6f',
         borderRadius: '10px',
+        transform: CSS.Transform.toString(transform), // these don't seem to do anything
+        transition,
     };
 
     return (

--- a/src/components/tool/draggableTool.tsx
+++ b/src/components/tool/draggableTool.tsx
@@ -9,6 +9,8 @@ import { Menu, MenuItem } from '@mui/material';
 import { Category, categoryToIconMappings, TOOL_WINDOW_ID } from '@/data/constants';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useCurrentInventoryState } from '@/app/inventory/page';
+import { InventoryActions } from '@/app/inventory/inventoryReducer';
 
 const ToolName = styled.div`
     font-size: 13px;
@@ -62,6 +64,8 @@ const DraggableTool = ({ _data, hoveredRow, setHoveredRow, deleteClick, containe
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [selectedIcon, setSelectedIcon] = useState<JSX.Element>(categoryToIconMappings[_data.category].icon);
 
+    const currentInventoryContext = useCurrentInventoryState();
+
     const open = Boolean(anchorEl);
 
     const handleDoubleClickName = () => {
@@ -81,15 +85,31 @@ const DraggableTool = ({ _data, hoveredRow, setHoveredRow, deleteClick, containe
     }
 
     const handleChangeName = (e: ChangeEvent<HTMLInputElement>) => {
-        let newData = { ...data }
-        newData.name = e.target.value
-        setData(newData)
+        let newTool = { ...data }
+        newTool.name = e.target.value
+        setData(newTool)
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REPLACE_TOOL,
+            payload: {
+                containerId: containerId,
+                toolId: id,
+                newTool: newTool
+            }
+        })
     };
 
     const handleChangeWeight = (e: ChangeEvent<HTMLInputElement>) => {
-        let newData = { ...data }
-        newData.weight = Number(e.target.value)
-        setData(newData) // this could be a race condition as we wait for the data to change...
+        let newTool = { ...data }
+        newTool.weight = Number(e.target.value)
+        setData(newTool) // this could be a race condition as we wait for the data to change...
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REPLACE_TOOL,
+            payload: {
+                containerId: containerId,
+                toolId: id,
+                newTool: newTool
+            }
+        })
     };
 
     const handleMouseEnter = (id: string) => {
@@ -109,10 +129,16 @@ const DraggableTool = ({ _data, hoveredRow, setHoveredRow, deleteClick, containe
         category: Category,
     ) => {
         setSelectedIcon(categoryToIconMappings[category].icon)
-        setData((prevData) => {
-            let newData = { ...prevData }
-            newData.category = category
-            return newData
+        let newTool = { ...data }
+        newTool.category = category
+        setData(newTool)
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REPLACE_TOOL,
+            payload: {
+                containerId: containerId,
+                toolId: id,
+                newTool: newTool
+            }
         })
         setAnchorEl(null);
     };

--- a/src/components/tool/toolWindow.tsx
+++ b/src/components/tool/toolWindow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
@@ -6,6 +6,8 @@ import DraggableTool from './draggableTool';
 import { TEST_DATA } from '@/data/testData';
 import { Category, TOOL_WINDOW_ID } from '@/data/constants';
 import { SortableContext } from '@dnd-kit/sortable';
+import { useCurrentInventoryState } from '@/app/inventory/page';
+import { InventoryActions } from '@/app/inventory/inventoryReducer';
 
 
 const Container = styled.div`
@@ -51,32 +53,51 @@ export interface Data {
 let initData: Data[] = TEST_DATA
 
 const ToolWindow: React.FC = () => {
-    const [data, setData] = useState<Data[]>(initData);
     const [hoveredRow, setHoveredRow] = useState<string>('');
     const [uniqueId, setUniqueId] = useState<number>(initData.length);
 
-    const addClick = () => {
-        const newData = [
-            {
-                id: String(uniqueId),
-                name: '',
-                category: Category.CLOTHING,
-                weight: 0,
-            },
-            ...data
-        ]
-        setUniqueId(uniqueId + 1);
-        setData(newData);
-    }
+    const currentInventoryContext = useCurrentInventoryState();
 
-    const deleteClick = (id: string) => {
-        const newData: Data[] = [];
-        data.forEach((row) => {
-            if (row.id !== id) {
-                newData.push(row)
+    useEffect(() => {
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.ADD_CONTAINER,
+            payload: {
+                containerId: TOOL_WINDOW_ID
             }
         })
-        setData(newData);
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.ADD_TOOLS,
+            payload: {
+                containerId: TOOL_WINDOW_ID,
+                newTools: TEST_DATA
+            }
+        })
+    }, [])
+
+    const addClick = () => {
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.ADD_TOOL,
+            payload: {
+                newTool: {
+                    id: String(uniqueId),
+                    name: '',
+                    category: Category.CLOTHING,
+                    weight: 0,
+                },
+                containerId: TOOL_WINDOW_ID,
+            }
+        })
+        setUniqueId(uniqueId + 1);
+    }
+
+    const deleteClick = (toolId: string) => {
+        currentInventoryContext.currentInventoryDispatcher({
+            type: InventoryActions.REMOVE,
+            payload: {
+                containerId: TOOL_WINDOW_ID,
+                toolId: toolId
+            }
+        })
     }
 
     return (
@@ -86,10 +107,10 @@ const ToolWindow: React.FC = () => {
                     {/* planning to be a search bar */}
                 </ToolContainerHeader>
                 <ToolContainerBody>
-                    <SortableContext id={TOOL_WINDOW_ID} items={data}>
-                        {data.map((row) => (
-                            <DraggableTool key={row.id} _data={row} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClick} setTools={setData} />
-                        ))}
+                    <SortableContext items={TOOL_WINDOW_ID in currentInventoryContext.currentInventory ? currentInventoryContext.currentInventory[TOOL_WINDOW_ID] : []}>
+                        {TOOL_WINDOW_ID in currentInventoryContext.currentInventory && currentInventoryContext.currentInventory[TOOL_WINDOW_ID].map((row) => {
+                            return <DraggableTool key={row.id} _data={row} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClick} containerId={TOOL_WINDOW_ID} />
+                        })}
                     </SortableContext>
                 </ToolContainerBody>
             </ToolScrollTable>

--- a/src/components/tool/toolWindow.tsx
+++ b/src/components/tool/toolWindow.tsx
@@ -4,7 +4,8 @@ import IconButton from '@mui/material/IconButton';
 import AddIcon from '@mui/icons-material/Add';
 import DraggableTool from './draggableTool';
 import { TEST_DATA } from '@/data/testData';
-import { Category } from '@/data/constants';
+import { Category, TOOL_WINDOW_ID } from '@/data/constants';
+import { SortableContext } from '@dnd-kit/sortable';
 
 
 const Container = styled.div`
@@ -85,9 +86,11 @@ const ToolWindow: React.FC = () => {
                     {/* planning to be a search bar */}
                 </ToolContainerHeader>
                 <ToolContainerBody>
-                    {data.map((row) => (
-                        <DraggableTool key={row.id} _data={row} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClick} />
-                    ))}
+                    <SortableContext id={TOOL_WINDOW_ID} items={data}>
+                        {data.map((row) => (
+                            <DraggableTool key={row.id} _data={row} hoveredRow={hoveredRow} setHoveredRow={setHoveredRow} deleteClick={deleteClick} setTools={setData} />
+                        ))}
+                    </SortableContext>
                 </ToolContainerBody>
             </ToolScrollTable>
             <ButtonContainer>

--- a/src/data/constants.tsx
+++ b/src/data/constants.tsx
@@ -72,4 +72,4 @@ export const categoryToIconMappings = {
     [Category.FIRSTAID]: { icon: <FirstAid size={25} />, label: Category.FIRSTAID },
 };
 
-export const TOOL_WINDOW_ID = 'toolId'
+export const TOOL_WINDOW_ID = 'window-tool'

--- a/src/data/constants.tsx
+++ b/src/data/constants.tsx
@@ -71,3 +71,5 @@ export const categoryToIconMappings = {
     [Category.TOILETPAPER]: { icon: <ToiletPaper size={25} />, label: Category.TOILETPAPER },
     [Category.FIRSTAID]: { icon: <FirstAid size={25} />, label: Category.FIRSTAID },
 };
+
+export const TOOL_WINDOW_ID = 'toolId'

--- a/src/data/testData.tsx
+++ b/src/data/testData.tsx
@@ -99,4 +99,10 @@ export const TEST_DATA = [
         category: Category.DEFENCE,
         weight: 300
     },
+    {
+        id: '16',
+        name: `Some absurdly long sentence to test out certain edge cases in the tool and backpack windows`,
+        category: Category.TOILETPAPER,
+        weight: 1
+    },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,12 +101,20 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dnd-kit/core@^6.3.1":
+"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
   integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
   dependencies:
     "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
     "@dnd-kit/utilities" "^3.2.2"
     tslib "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,6 +3304,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz"


### PR DESCRIPTION
containers are dnd kit sortable. Tools in tool window cannot be dnd sorted. It will be sortable alphabetically or by weight in the future.

I need to make a designated drop zone to tell users that tools will get copied instead of swapping between containers.